### PR TITLE
Console debugging and a start on players rejoining games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Debug trigger file
+debug
+
 # Logs
 logs
 *.log

--- a/client/bower_components/acquire-join-page/acquire-join-page.html
+++ b/client/bower_components/acquire-join-page/acquire-join-page.html
@@ -51,6 +51,8 @@
       is: 'acquire-join-page',
       
       created: () => {
+        socket.on('assigned UUID', (msg) => localStorage.acquireUUID = msg);
+        
         socket.on('joined game', function(msg) {
           console.log('joined game');
           window.location.hash = '#lobby/' + msg;

--- a/client/bower_components/acquire-lobby-page/acquire-lobby-page.html
+++ b/client/bower_components/acquire-lobby-page/acquire-lobby-page.html
@@ -57,6 +57,8 @@
       created() {
         console.log(Acquire.gameID);
         
+        socket.on('assigned UUID', (msg) => localStorage.acquireUUID = msg);
+        
         socket.on('invalid game', function() {
           console.log('invalid game');
           window.location.hash = '#join';

--- a/server/acquire.js
+++ b/server/acquire.js
@@ -28,7 +28,7 @@ function log(output) {
 }
 
 var debugCommands = {
-  loadgame: (input) => {
+  load: (input) => {
     console.log('pretending to load game', input[0]);
   },
   help: () => {

--- a/server/acquire.js
+++ b/server/acquire.js
@@ -23,15 +23,16 @@ function consoleListen() {
   stdin.addListener('data', (buffer) => handleInput(buffer.toString().trim()) )
 }
 
+function log(output) {
+  console.log('\n' + output + '\n');
+}
+
 var debugCommands = {
   loadgame: (input) => {
     console.log('pretending to load game', input[0]);
   },
   help: () => {
-    console.log();
-    console.log('available commands:')
-    Object.keys(debugCommands).forEach( (c) => console.log('-', c));
-    console.log();
+    log('available commands:\n' + Object.keys(debugCommands).map( (c) => '- ' + c ).join('\n'));
   }
 }
 
@@ -50,15 +51,9 @@ function handleInput(i) {
         .map( (c) => {
           return { command: c, dist: levenshtein(command, c) }
         } )
-        // .sort( (a, b) => {
-        //   if (a.dist < b.dist) return -1;
-        //   if (a.dist > b.dist) return 1;
-        //   return 0;
-        .sort( (a, b) => (a.dist < b.dist) ? -1 : ((a.dist > b.dist) ? 1 : 0) )[0];
-      console.log();
-      console.log('Unknown command. Did you mean');
-      console.log('    ' + bestGuess.command);
-      console.log();
+        .sort( (a, b) => (a.dist < b.dist) ? -1 : ((a.dist > b.dist) ? 1 : 0) )
+        [0];
+      log('Unknown command. Did you mean\n    ' + bestGuess.command);
     }
   } else handleInput('help');
 }

--- a/server/acquire.js
+++ b/server/acquire.js
@@ -9,3 +9,56 @@ var connections = [];
 io.on('connection', (socket) => connections.push(new Connection(socket)) );
 
 console.log('Server started');
+
+
+fs.stat('./debug', (err, stats) => { if (!err) consoleListen() } );
+
+
+// Debugging functions
+
+function consoleListen() {
+  console.log('Debugging started');
+  
+  var stdin = process.openStdin();
+  stdin.addListener('data', (buffer) => handleInput(buffer.toString().trim()) )
+}
+
+var debugCommands = {
+  loadgame: (input) => {
+    console.log('pretending to load game', input[0]);
+  },
+  help: () => {
+    console.log();
+    console.log('available commands:')
+    Object.keys(debugCommands).forEach( (c) => console.log('-', c));
+    console.log();
+  }
+}
+
+var levenshtein = require('./levenshtein').getEditDistance;
+
+function handleInput(i) {
+  if (i.length > 0) {
+    let input = i.split(' ');
+    let command = input[0];
+    
+    if (Object.keys(debugCommands).indexOf(command) !== -1) {
+      debugCommands[command](input.slice(1));
+    } else {
+      let bestGuess =
+        Object.keys(debugCommands)
+        .map( (c) => {
+          return { command: c, dist: levenshtein(command, c) }
+        } )
+        // .sort( (a, b) => {
+        //   if (a.dist < b.dist) return -1;
+        //   if (a.dist > b.dist) return 1;
+        //   return 0;
+        .sort( (a, b) => (a.dist < b.dist) ? -1 : ((a.dist > b.dist) ? 1 : 0) )[0];
+      console.log();
+      console.log('Unknown command. Did you mean');
+      console.log('    ' + bestGuess.command);
+      console.log();
+    }
+  } else handleInput('help');
+}

--- a/server/board.js
+++ b/server/board.js
@@ -19,22 +19,22 @@ class Board {
   playTile(row, col) {
     let neighbors = this.getNeighbors(row, col);
     
-    if (neighbors.every( (cell) => ! grid[cell.row][cell.col].filled )) {
+    if (neighbors.every( (cell) => ! this.grid[cell.row][cell.col].filled )) {
       this.grid[row][col].filled = true;
       return { success: true, orphan: true }
     } else {
-      if (neighbors.every( (cell) => ! grid[cell.row][cell.col].chain )) {
+      if (neighbors.every( (cell) => ! this.grid[cell.row][cell.col].chain )) {
         this.grid[row][col].filled = true;
         return { success: true, newChain: true }
       } else {
-        let chainMembers = neighbors.filter( (cell) => grid[cell.row][cell.col].chain );
+        let chainMembers = neighbors.filter( (cell) => this.grid[cell.row][cell.col].chain );
         
         if (chainMembers.length == 1) {
           this.grid[row][col].filled = true;
           return { success: true, expandChain: true }
         } else {
           let firstChain = this.grid[row][col].chain;
-          if (neighbors.slice(1).each( (cell) => grid[cell.row][cell.col].chain == firstChain )) {
+          if (neighbors.slice(1).each( (cell) => this.grid[cell.row][cell.col].chain == firstChain )) {
             this.grid[row][col].filled = true;
             return { success: true, expandChain: true }
           } else {

--- a/server/board.js
+++ b/server/board.js
@@ -17,7 +17,7 @@ class Board {
   }
   
   playTile(row, col) {
-    let neighbors = getNeighbors(row, col);
+    let neighbors = this.getNeighbors(row, col);
     
     if (neighbors.every( (cell) => ! grid[cell.row][cell.col].filled )) {
       this.grid[row][col].filled = true;

--- a/server/connection.js
+++ b/server/connection.js
@@ -59,8 +59,13 @@ class Connection {
   
   disconnect() {
     console.log('user disconnected');
-    if (this.game)
-      this.game.removePlayer(this.socket.id);
+    if (this.game) {
+      if (this.game.gameState == 'lobby') {
+        this.game.removePlayer(this.id);
+      } else {
+        this.game.disconnectPlayer(this.id);
+      }
+    }
   }
   
   updateNickname(msg) {

--- a/server/connection.js
+++ b/server/connection.js
@@ -3,6 +3,7 @@
 var io = require('./shared').io;
 var gamesManager = new (require('./gamesManager'))();
 var Player = require('./player');
+var uuid = require('node-uuid').v4;
 var he = require('he');
 
 class Connection {
@@ -10,8 +11,8 @@ class Connection {
     console.log('a user connected');
     this.socket = socket;
     
-    this.gameID = null;
-    this.game = null;
+    this.gameID = undefined;
+    this.game = undefined;
     
     this.registerMessages();
   }
@@ -24,14 +25,15 @@ class Connection {
     var self = this;
     this.socket.on('new game',         ()    => self.newGame());
     this.socket.on('join game',        (msg) => self.joinGame(msg));
+    this.socket.on('rejoin game',      (msg) => self.rejoinGame(msg));
     this.socket.on('disconnect',       ()    => self.disconnect());
     this.socket.on('update nickname',  (msg) => self.updateNickname(msg));
-    this.socket.on('start game',       ()    => self.game.startGame());
-    this.socket.on('board ready',      ()    => self.game.boardReady());
-    this.socket.on('tile chosen',      (msg) => self.game.tileChosen(this.id, msg));
-    this.socket.on('merger chosen',    (msg) => self.game.mergerChosen(this.id, msg));
-    this.socket.on('stock decision',   (msg) => self.game.stockDecision(this.id, msg));
-    this.socket.on('stocks purchased', (msg) => self.game.stocksPurchased(this.id, msg));
+    this.socket.on('start game',       ()    => { if (self.game) self.game.startGame() });
+    this.socket.on('board ready',      ()    => { if (self.game) self.game.boardReady() });
+    this.socket.on('tile chosen',      (msg) => { if (self.game) self.game.tileChosen(this.id, msg) });
+    this.socket.on('merger chosen',    (msg) => { if (self.game) self.game.mergerChosen(this.id, msg) });
+    this.socket.on('stock decision',   (msg) => { if (self.game) self.game.stockDecision(this.id, msg) });
+    this.socket.on('stocks purchased', (msg) => { if (self.game) self.game.stocksPurchased(this.id, msg) });
   }
   
   // Callbacks
@@ -46,12 +48,31 @@ class Connection {
   }
   
   joinGame(msg) {
-    this.game = gamesManager.findGame(msg.id);
-    if (this.game) {
+    let game = gamesManager.findGame(msg.id);
+    if (game) {
+      this.game = game;
       this.gameID = msg.id;
       this.socket.join(msg.id);
-      this.game.addPlayer(new Player(this.socket.id, he.escape(msg.nickname)));
+      this.game.addPlayer(new Player(this.socket.id, uuid(), he.escape(msg.nickname)));
       this.socket.emit('joined game', msg.id);
+    } else {
+      this.socket.emit('invalid game');
+    }
+  }
+  
+  rejoinGame(msg) {
+    let game = gamesManager.findGame(msg.id);
+    if (game) {
+      if (game.rejoinPlayer({ uuid: msg.uuid, id: this.id })) {
+        this.game = game;
+        this.gameID = msg.id;
+        this.socket.join(msg.id);
+        this.socket.emit('rejoined game', msg.id);
+        console.log('rejoined game', msg.id);
+      } else {
+        this.socket.emit('forbidden connection');
+        console.log('forbidden connection');
+      }
     } else {
       this.socket.emit('invalid game');
     }
@@ -70,7 +91,7 @@ class Connection {
   
   updateNickname(msg) {
     console.log('Player', this.socket.id, 'updating nickname to', msg.val);
-    this.game.updateNickname(this.socket.id, msg.val);
+    if (this.game) this.game.updateNickname(this.socket.id, msg.val);
   }
 };
 

--- a/server/connection.js
+++ b/server/connection.js
@@ -53,8 +53,10 @@ class Connection {
       this.game = game;
       this.gameID = msg.id;
       this.socket.join(msg.id);
-      this.game.addPlayer(new Player(this.socket.id, uuid(), he.escape(msg.nickname)));
+      let newUUID = uuid();
+      this.game.addPlayer(new Player(this.socket.id, newUUID, he.escape(msg.nickname)));
       this.socket.emit('joined game', msg.id);
+      this.socket.emit('assigned UUID', newUUID);
     } else {
       this.socket.emit('invalid game');
     }

--- a/server/game.js
+++ b/server/game.js
@@ -149,14 +149,15 @@ class Game {
       console.log(player.id, 'has tiles', player.tiles);
     }
     
-    // this.broadcast('next turn', /* whose ~line~ turn is it anyway? */ )
-    
-    // announce the next turn
+    this.nextTurn(true);
   }
   
-  nextTurn() {
-    this.currentPlayer = ++this.currentPlayer % this.players.count;
-    // this.broadcast('next turn', /* whose ~line~ turn is it anyway? */ )
+  nextTurn(firstTurn) {
+    if (! firstTurn) this.currentPlayer = ++this.currentPlayer % this.players.count;
+    let player = this.players[this.currentPlayer];
+    this.broadcast('next turn', player.uuid);
+    this.whisper(player.id, 'play a tile');
+    player.waitingFor = { ev: 'play a tile' };
   }
   
   findPlayer(id) {

--- a/server/game.js
+++ b/server/game.js
@@ -9,6 +9,7 @@ class Game {
     this.id = id;
     this.players = [];
     this.currentPlayer = undefined;
+    this.gameState = 'lobby';
     this.turnState = undefined;
     
     this.board = new Board();
@@ -23,10 +24,13 @@ class Game {
   }
   
   whisper(to, ev, data) {
-    if (typeof data === undefined)
-      io.sockets.connected[to].emit(ev);
-    else
-      io.sockets.connected[to].emit(ev, data);
+    if (typeof to !== undefined) {
+      if (typeof data === undefined) {
+        io.sockets.connected[to].emit(ev);
+      } else {
+        io.sockets.connected[to].emit(ev, data);
+      }
+    }
   }
   
   addPlayer(player) {
@@ -41,6 +45,14 @@ class Game {
       }
     }
     this.pushSetupState();
+  }
+  
+  disconnectPlayer(id) {
+    for (let i = 0; i < this.players.length; i++) {
+      if (id === this.players[i].id) {
+        this.players[i].disconnected();
+      }
+    }
   }
   
   updateNickname(id, newName) {
@@ -98,8 +110,8 @@ class Game {
     let order = this.firstPlayer();
     
     console.log(order);
+    this.gameState = 'main';
     this.broadcast('game started', order);
-    // tell the board about players
   }
   
   boardReady() {

--- a/server/game.js
+++ b/server/game.js
@@ -24,7 +24,7 @@ class Game {
   }
   
   whisper(to, ev, data) {
-    if (typeof to !== undefined) {
+    if (typeof io.sockets.connected[to] !== undefined) {
       if (typeof data === undefined) {
         io.sockets.connected[to].emit(ev);
       } else {

--- a/server/game.js
+++ b/server/game.js
@@ -55,6 +55,22 @@ class Game {
     }
   }
   
+  rejoinPlayer(msg) {
+    for (let i = 0; i < this.players.length; i++) {
+      if (msg.uuid === this.players[i].uuid) {
+        this.players[i].id = msg.id;
+        whisper(this.players[i].id, 'game state', this.dumpGameState());
+        return true;
+      }
+    }
+    return false;
+  }
+  
+  dumpGameState() {
+    console.log('pretending to dump game state');
+    return {};
+  }
+  
   updateNickname(id, newName) {
     for (let i = 0; i < this.players.length; i++) {
       if (this.players[i].id === id) {

--- a/server/game.js
+++ b/server/game.js
@@ -153,7 +153,7 @@ class Game {
   }
   
   nextTurn(firstTurn) {
-    if (! firstTurn) this.currentPlayer = ++this.currentPlayer % this.players.count;
+    if (! firstTurn) this.currentPlayer = ++this.currentPlayer % this.players.length;
     let player = this.players[this.currentPlayer];
     this.broadcast('next turn', player.uuid);
     this.whisper(player.id, 'play a tile');

--- a/server/game.js
+++ b/server/game.js
@@ -59,16 +59,28 @@ class Game {
     for (let i = 0; i < this.players.length; i++) {
       if (msg.uuid === this.players[i].uuid) {
         this.players[i].id = msg.id;
-        whisper(this.players[i].id, 'game state', this.dumpGameState());
+        this.whisper(msg.id, 'game state', {
+          game: this.dumpGameState(),
+          player: this.players[i].dumpPlayerState()
+        });
         return true;
+        let waitingFor = this.players[i].waitingFor;
+        if (waitingFor) {
+          this.whisper(msg.id, waitingFor.ev, waitingFor.data);
+        }
       }
     }
     return false;
   }
   
   dumpGameState() {
-    console.log('pretending to dump game state');
-    return {};
+    return {
+      players: this.players,
+      currentPlayer: this.players[i].id,
+      gameState: this.gameState,
+      turnState: this.turnState,
+      board: this.board.grid
+    };
   }
   
   updateNickname(id, newName) {

--- a/server/levenshtein.js
+++ b/server/levenshtein.js
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2011 Andrei Mackenzie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// Compute the edit distance between the two given strings
+exports.getEditDistance = function(a, b){
+  if(a.length == 0) return b.length; 
+  if(b.length == 0) return a.length; 
+
+  var matrix = [];
+
+  // increment along the first column of each row
+  var i;
+  for(i = 0; i <= b.length; i++){
+    matrix[i] = [i];
+  }
+
+  // increment each column in the first row
+  var j;
+  for(j = 0; j <= a.length; j++){
+    matrix[0][j] = j;
+  }
+
+  // Fill in the rest of the matrix
+  for(i = 1; i <= b.length; i++){
+    for(j = 1; j <= a.length; j++){
+      if(b.charAt(i-1) == a.charAt(j-1)){
+        matrix[i][j] = matrix[i-1][j-1];
+      } else {
+        matrix[i][j] = Math.min(matrix[i-1][j-1] + 1, // substitution
+                                Math.min(matrix[i][j-1] + 1, // insertion
+                                         matrix[i-1][j] + 1)); // deletion
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+};

--- a/server/player.js
+++ b/server/player.js
@@ -5,10 +5,18 @@ class Player {
     this.id = id;
     this.uuid = uuid;
     this.nickname = nickname;
+    this.waitingFor = undefined;
     this.tiles = [];
     // money
     // stock
     // etc.
+  }
+  
+  dumpPlayerState() {
+    return {
+      nickname: this.nickname,
+      tiles: this.tiles
+    };
   }
   
   disconnected() {

--- a/server/player.js
+++ b/server/player.js
@@ -10,6 +10,11 @@ class Player {
     // etc.
   }
   
+  disconnected() {
+    this.id = undefined;
+    console.log(this.nickname, 'lost connection');
+  }
+  
   addTile(tile) {
     this.tiles.push(tile);
   }

--- a/server/player.js
+++ b/server/player.js
@@ -1,8 +1,9 @@
 'use strict';
 
 class Player {
-  constructor(id, nickname) {
+  constructor(id, uuid, nickname) {
     this.id = id;
+    this.uuid = uuid;
     this.nickname = nickname;
     this.tiles = [];
     // money

--- a/server/player.js
+++ b/server/player.js
@@ -24,13 +24,7 @@ class Player {
   }
   
   hasTile(row, col) {
-    let result = false;
-    this.tiles.forEach( (t) => {
-      if (t.row == row && t.col == col) {
-        result = true;
-      }
-    } );
-    return result;
+    return this.tiles.some( (t) => t.row == row && t.col == col );
   }
 };
 


### PR DESCRIPTION
This PR adds a console debugging interface that we can add debugging commands to. To enable debugging, `touch server/debug`.

It also starts on the server-side logic for reconnecting players to games. I haven’t done much with the client yet, so a lot of this code will be better tested after that happens, but I do at least know that everything works as it did before, so this won't break anything :smile:

When a player connects to a game, the server assigns them a UUID. The server expects that a player will use that UUID to identify itself when reconnecting to a game. To prevent one client from taking over another’s game, the server makes sure that the original socket has disconnected before allowing the reconnection.
